### PR TITLE
Guard BleGamepad NimBLE initialization

### DIFF
--- a/blegamepad/BleGamepad.cpp
+++ b/blegamepad/BleGamepad.cpp
@@ -1039,7 +1039,9 @@ void BleGamepad::bleSetup()
 
   UNUSED(xReturned);
 
-  NimBLEDevice::init("OnStepX");
+  if (!NimBLEDevice::isInitialized()) {
+    NimBLEDevice::init("OnStepX");
+  }
   NimBLEDevice::setSecurityAuth(BLE_SM_PAIR_AUTHREQ_SC);
 
   /** Optional: set the transmit power */


### PR DESCRIPTION
## Summary
- Add an initialization guard in `blegamepad/BleGamepad.cpp` so `NimBLEDevice::init("OnStepX")` is called only when NimBLE is not already initialized.

## Why
When multiple plugins use NimBLE in the same firmware, plugin initialization order should not matter. Without this guard, `BleGamepad` can reinitialize NimBLE and conflict with an already initialized BLE stack.

## Change
```cpp
if (!NimBLEDevice::isInitialized()) {
  NimBLEDevice::init("OnStepX");
}
```

This keeps standalone behavior unchanged and improves coexistence with other BLE plugins.