### PR TITLE
Use short response for alt-az set-target commands

### DIFF
--- a/website/libApp/cmd/Cmd.cpp
+++ b/website/libApp/cmd/Cmd.cpp
@@ -66,7 +66,7 @@ bool OnStepCmd::processCommand(const char* cmd, char* response, long timeOutMs) 
       if (strchr("AEGCMS0123456789", cmd[2])) noResponse = true;
     } else
     if (cmd[1] == 'S') {
-      if (strchr("CLSGtgMNOPrdhoTBX", cmd[2])) shortResponse = true;
+      if (strchr("CLSGtgMNOPrdhoTBXza", cmd[2])) shortResponse = true;
     } else
     if (cmd[1] == 'L') {
       if (strchr("BNCDL!",cmd[2])) noResponse = true;


### PR DESCRIPTION
I've noticed when using `Cmd.cpp` in a separate project that the `Sa` and `Sz` commands did just hung and timeout. Looking at the [docs](https://onstep.groups.io/g/main/wiki/23755), they do return `0` and `1` on failure or success, so they seem to match the "short response" pattern, but they were missing from this line.

Adding `za` here fixed the issue.